### PR TITLE
Adding shift-enter keymap to emulate intellij Start New Line behavior.

### DIFF
--- a/keymaps/intellij-idea-keymap.cson
+++ b/keymaps/intellij-idea-keymap.cson
@@ -230,6 +230,9 @@
   # Duplicate current line or selected block
   'ctrl-d': 'editor:duplicate-lines'
 
+  # Start new line
+  'shift-enter': 'editor:newline-below'
+
   # Select successively increasing code blocks
   'ctrl-w': 'editor:select-to-next-subword-boundary'
 

--- a/keymaps/intellij-idea-keymap.cson
+++ b/keymaps/intellij-idea-keymap.cson
@@ -233,6 +233,9 @@
   # Start new line
   'shift-enter': 'editor:newline-below'
 
+  # Change selected text to upper-case
+  'ctrl-shift-u': 'editor:upper-case'
+
   # Select successively increasing code blocks
   'ctrl-w': 'editor:select-to-next-subword-boundary'
 


### PR DESCRIPTION
Mapping an additional shortcut.
