### PR TITLE
Adding ctrl-shift-u to upper-case selection.  Does not toggle like In…

### DIFF
--- a/keymaps/intellij-idea-keymap.cson
+++ b/keymaps/intellij-idea-keymap.cson
@@ -230,6 +230,9 @@
   # Duplicate current line or selected block
   'ctrl-d': 'editor:duplicate-lines'
 
+  # Change selected text to upper-case
+  'ctrl-shift-u': 'editor:upper-case'
+
   # Select successively increasing code blocks
   'ctrl-w': 'editor:select-to-next-subword-boundary'
 


### PR DESCRIPTION
I am not sure what we should do with this one as IntelliJ toggles case with ctrl-shift-u but atom requires a separate mapping for upper and lower casing.  Locally, I am using:

'.platform-win32 atom-workspace atom-text-editor':
  # Change selected text to lower-case
  'ctrl-shift-l': 'editor:lower-case'

But we might not want to do this in the intellij keymap as ctrl-shift-l is mapped as an alternative binding to 'Find Previous / Move to Previous Occurance'

Any Ideas? 
